### PR TITLE
chore(): add flag to filter out merged to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Are you sure? (y/n)
 
 - use '--merged' or '-m' to only delete branches MERGED into main (or master) branch matching the supplied pattern
 
+<i>Note: branches that are newly created from the main branch with no new commits that match the search pattern will also be deleted since they are fully merged by default.</i>
+
 E.g
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Gitcrop Branch Batch Deletion Command Line Utility for Git Repositories :scissors:
 
-Lets face it - those pesky old redundant local branches can quickly start to get out of hand and clog up your repo. :face_with_spiral_eyes:
+Lets face it - old redundant branches can quickly start to get out of hand and clog up your local repo. :face_with_spiral_eyes:
 
-Deleting branches one by one can be a real pain and using the usual Git command can mean accidentally deleting the wrong branch or deleting a branch you don't want to delete. :cursing_face:
+Tidying up a local repo by deleting branches one by one can be a real pain and using the usual Git command can mean accidentally deleting the wrong branch or deleting a branch you don't want to delete. :cursing_face:
 
 Git Crop is a simple bash script that allows you to safely delete all branches matching a given pattern in a LOCAL git repository with a single command.
 
-The search pattern automatically excludes the 'main' or 'develop' branches to prevent deleting them by accident. Other protected branches patterns can be added into the EXCEPTIONS variable command in the script.
+The search pattern automatically excludes protected branches such as the default ('main' or 'master') branch and any 'develop' branches to prevent deleting them by accident. Other protected branches patterns can be added into the EXCEPTIONS variable command in the script.
 
 This script is easier and safer than using the usual Git command below:
 
@@ -34,6 +34,18 @@ WARNING: The following branches will be PERMANENTLY deleted:
   chore/pr-21
 Are you sure? (y/n)
 ```
+
+## Options
+
+- use '--merged' or '-m' to only delete branches MERGED into main (or master) branch matching the supplied pattern
+
+E.g
+
+```bash
+gitcrop feature/ --merged
+```
+
+will only delete branches merged into main that match the pattern 'feature/'
 
 ## Installation
 

--- a/gitcrop.sh
+++ b/gitcrop.sh
@@ -1,33 +1,69 @@
 #!/bin/bash
 
+# Verify the main branch name
+DEFAULT_BRANCH="main"
+if ! git rev-parse --verify "refs/heads/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"  # Fallback to 'master' if 'main' doesn't exist
+fi
+
+# Define branches to exclude from deletion
+EXCEPTIONS="$DEFAULT_BRANCH|develop"
+
+# Initialize variables
+MERGED=false
+PATTERN=""
+
+# Parse arguments dynamically (allowing --merged first or last)
+for arg in "$@"; do
+    if [ "$arg" == "--merged" ] || [ "$arg" == "-m" ]; then
+        MERGED=true
+    else
+        PATTERN="$arg"
+    fi
+done
+
 # Ensure a pattern is provided
-if [ -z "$1" ]; then
-    echo "Usage: gitcrop <pattern>"
-    echo "This script deletes all local branches matching the specified pattern."
-    echo "Example: gitcrop feature/"
+if [ -z "$PATTERN" ]; then
+    echo ""
+    echo "Usage: gitcrop [--merged | -m] <pattern>"
+    echo ""
+    echo "Use --merged or -m to delete only branches that are fully merged into the main branch."
+    echo "Branches matching the pattern will be deleted, excluding: $EXCEPTIONS"
+    echo ""
+    echo "Example: gitcrop --merged 'feature/*' or gitcrop 'bugfix/*'"
     exit 1
 fi
 
-PATTERN="$1"
-EXCEPTIONS="main|develop"  # Add other branches to exclude as needed
-
-# Get a list of branches matching the pattern, excluding 'main' and 'develop'. 
-BRANCHES=$(git branch | grep -E "$PATTERN" | grep -v -E "$EXCEPTIONS")
+# Get the list of merged branches matching the pattern, excluding exceptions
+if [ "$MERGED" = true ]; then
+    LOCAL_BRANCHES=$(git branch --merged "$DEFAULT_BRANCH" | grep -E "$PATTERN" | grep -Ev "$EXCEPTIONS")
+else
+    LOCAL_BRANCHES=$(git branch | grep -E "$PATTERN" | grep -Ev "$EXCEPTIONS")
+fi
 
 # Check if any branches match the pattern
-if [ -z "$BRANCHES" ]; then
-    echo "No branches found matching pattern: $PATTERN"
+if [ -z "$LOCAL_BRANCHES" ]; then
+    if [ "$MERGED" = true ]; then
+        echo "No local branches found matching pattern: $PATTERN that were also merged into '$DEFAULT_BRANCH' (excluding $EXCEPTIONS branches)"
+    else
+        echo "No local branches found matching pattern: $PATTERN (excluding $EXCEPTIONS branches)"
+    fi
     exit 0
 fi
 
-# Confirm deletion
-echo "WARNING: The following branches will be PERMANENTLY deleted:"
-echo "$BRANCHES"
+# Display appropriate confirmation message
+echo "The following local branches will be deleted:"
+echo "$LOCAL_BRANCHES"
+
+if [ "$MERGED" = true ]; then
+    echo "(These branches were fully merged into '$DEFAULT_BRANCH'.)"
+fi
+
 read -p "Are you sure? (y/n) " CONFIRM
 
 if [[ "$CONFIRM" =~ ^[Yy]$ ]]; then
-    echo "$BRANCHES" | xargs git branch -D
-    echo "Branches deleted."
+    echo "$LOCAL_BRANCHES" | xargs git branch -D
+    echo "Local branches deleted."
 else
     echo "Deletion cancelled."
 fi


### PR DESCRIPTION
- add the -m or --merged flag to filter out only branches merged or matching default main/master branch.